### PR TITLE
Include redis version. Old link was dead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN apt-get update --fix-missing && DEBIAN_FRONTEND=nointeractive apt-get instal
  && rm -rf /var/lib/apt/lists/*
 
 # Install Redis
-RUN wget http://download.redis.io/releases/redis-stable.tar.gz && tar xzf redis-stable.tar.gz
-WORKDIR /opt/redis-stable
+RUN wget http://download.redis.io/releases/redis-3.2.6.tar.gz && tar xzf redis-3.2.6.tar.gz
+WORKDIR /opt/redis-3.2.6
 RUN make && make install 
 WORKDIR /opt/TangoService/Tango/
 


### PR DESCRIPTION
The old link used to download redis (http://download.redis.io/releases/redis-stable.tar.gz) was removed and caused a 404. Updated to a specific version so redis will still be installed (http://download.redis.io/releases/redis-3.2.6.tar.gz).

Version 3.2.6 is old. This version was chosen because it's what's running on the AutoLab deployment so it's proven to work. Latest version of redis is 7.0.9 at the time of writing.

Changes proposed in this PR:
-Fix redis download link in Dockerfile