### PR TITLE
Update Dockerfile_CSE116 for the cse_116 grading image

### DIFF
--- a/vmms/Dockerfile_CSE116
+++ b/vmms/Dockerfile_CSE116
@@ -1,6 +1,6 @@
 # Autolab - autograding docker image for general software engineering
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 MAINTAINER David Dobmeier <daviddob@buffalo.edu>
 
 #C++ Setup
@@ -11,22 +11,19 @@ RUN apt-get install -y build-essential
 RUN apt-get install -y libcunit1-dev libcunit1-doc libcunit1
 
 #Python Setup
+RUN apt-get update && apt-get install -y software-properties-common gcc
+RUN add-apt-repository -y ppa:deadsnakes/ppa
 RUN apt-get update --fix-missing && \
     DEBIAN_FRONTEND=nointeractive apt-get install -y \
-    python3 python3-numpy python3-nose python3-pandas \
-    python python-numpy python-nose \
-    pep8 python3-pip \
-    && \
-    pip install --upgrade setuptools
+    python3.12 python3-numpy python3-nose python3-pandas \
+    pep8 python3-pip && pip install --upgrade setuptools
 
 #Java 19 Setup
 RUN apt update
 RUN apt-get install -y wget
-RUN wget https://download.oracle.com/java/19/latest/jdk-19_linux-x64_bin.deb
+RUN wget https://download.oracle.com/java/21/latest/jdk-21_linux-x64_bin.deb
 RUN apt install -y libc6-x32 libc6-i386 libasound2 libxi6 libxtst6
-RUN dpkg -i jdk-19_linux-x64_bin.deb
-RUN update-alternatives --install /usr/bin/java java /usr/lib/jvm/jdk-19/bin/java 3000
-RUN update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/jdk-19/bin/javac 3000
+RUN dpkg -i jdk-21_linux-x64_bin.deb
 
 #Utility setup
 RUN apt-get install -y unzip


### PR DESCRIPTION
Update the CSE116 Dockerfile for the cse_116 grading image

Changes proposed in this PR:
-  Update from Ubuntu 20.04 to 22.04
-  Update from Python3.8 to 3.12
-  Update from JDK19 to 21
